### PR TITLE
handle multiple IPs in XFF

### DIFF
--- a/pkg/reqHandler.go
+++ b/pkg/reqHandler.go
@@ -93,7 +93,11 @@ func GetHostname(r *http.Request) string {
 func GetIP(r *http.Request) string {
 	forwarded := r.Header.Get("X-FORWARDED-FOR")
 	if forwarded != "" {
-		return forwarded
+		// X-Forwarded-For can contain multiple IPs separated by commas
+		parts := strings.Split(forwarded, ",")
+		if len(parts) > 0 {
+			return strings.TrimSpace(parts[0]) // Return the client IP only
+		}
 	}
 	ip := r.RemoteAddr
 	if colonIndex := strings.LastIndex(ip, ":"); colonIndex != -1 {


### PR DESCRIPTION
### Current scenario

If `X-FORWARDED-FOR` has multiple IPs including source client IP and proxy or load balancer IPs, then `src_ip` field also having all those IPs.

```
"header_x-forwarded-for":"10.0.0.5, 10.1.0.15, 10.2.0.14"
"src_ip":"10.0.0.5, 10.1.0.15, 10.2.0.14"
```

### Expected scenario

If XFF has many IPs then `src_ip` should contain only original client source IP. Because `src_ip` represents attacker or client source IP. Additionally we can use anyway `header_x-forwarded-for` field to get the proxy IPs.
https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/X-Forwarded-For#client

```
"header_x-forwarded-for":"10.0.0.5, 10.1.0.15, 10.2.0.14"
"src_ip":"10.0.0.5"
```